### PR TITLE
removed print statement from sampling.jl

### DIFF
--- a/src/neural_networks/sampling.jl
+++ b/src/neural_networks/sampling.jl
@@ -27,7 +27,6 @@ function optimize_by_sampling!(jump_model::JuMP.Model, sample_points; enhanced=t
 
     for (sample, input) in enumerate(eachcol(sample_points))
 
-        print("$sample ")
         forward_pass!(jump_model, input)
 
         # fix binary variables


### PR DESCRIPTION
Remove the print statement on the sampling.jl file to avoid printing the values when calling the optimize_by_sampling function.